### PR TITLE
feat: 添加剪贴板粘贴功能并更新文本处理逻辑

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,17 +5,22 @@ import FormatText from './components/FormatText.vue'
 import TipText from './components/TipText.vue'
 import ImageDisplay from './components/ImageDisplay.vue'
 
-const input = ref('')
+const clipboardInput = ref('')
+const tipText = ref('')
+
+const updateText = (text: string) => {
+  clipboardInput.value = text
+}
 </script>
 
 <template>
   <div class="main-container">
     <div class="main-left-container">
-      <ActionButtons />
-      <FormatText :text="input" />
+      <ActionButtons @update-text="updateText" />
+      <FormatText :text="clipboardInput" />
     </div>
     <div class="main-right-container">
-      <TipText :text="input" />
+      <TipText :text="tipText" />
       <ImageDisplay />
     </div>
   </div>

--- a/src/components/ActionButtons.vue
+++ b/src/components/ActionButtons.vue
@@ -1,6 +1,21 @@
+<script setup lang="ts">
+import { defineEmits } from 'vue'
+
+const emit = defineEmits(['updateText'])
+
+const handlePaste = async () => {
+  try {
+    const text = await navigator.clipboard.readText()
+    emit('updateText', text)
+  } catch (err) {
+    console.error('读取剪贴板失败:', err)
+  }
+}
+</script>
+
 <template>
   <div class="main-left-button-container">
-    <el-button type="primary" class="action-button">粘贴</el-button>
+    <el-button type="primary" class="action-button" @click="handlePaste">粘贴</el-button>
     <el-button type="primary" class="action-button">记录</el-button>
     <el-button type="primary" class="action-button">模式1</el-button>
     <el-button type="primary" class="action-button">听听看</el-button>


### PR DESCRIPTION
在ActionButtons组件中添加了剪贴板粘贴功能，通过点击按钮读取剪贴板内容并更新父组件的输入文本。同时将App.vue中的`input`变量重命名为`clipboardInput`，并新增`tipText`变量以区分不同用途的文本。这些更改提升了应用的交互性和代码的可读性。